### PR TITLE
Prng

### DIFF
--- a/u2flib/Crypto/RandomChallengeGenerator.cs
+++ b/u2flib/Crypto/RandomChallengeGenerator.cs
@@ -15,6 +15,8 @@ namespace u2flib.Crypto
 {
     public class RandomChallengeGenerator : IChallengeGenerator
     {
+        // version 1.7 of bouncy castle library uses sha1 which the security industry seems to moving away from 
+        // so manual setting generator to sha256 which is the default in the upcoming 1.8 bouncy castle library.
         private static readonly IRandomGenerator Generator = new DigestRandomGenerator(new Sha256Digest());
         private static readonly SecureRandom Random = new SecureRandom(Generator);
 

--- a/u2flib/Crypto/RandomChallengeGenerator.cs
+++ b/u2flib/Crypto/RandomChallengeGenerator.cs
@@ -7,13 +7,16 @@
  * https://developers.google.com/open-source/licenses/bsd
  */
 
+using Org.BouncyCastle.Crypto.Digests;
+using Org.BouncyCastle.Crypto.Prng;
 using Org.BouncyCastle.Security;
 
 namespace u2flib.Crypto
 {
     public class RandomChallengeGenerator : IChallengeGenerator
     {
-        private static readonly SecureRandom Random = new SecureRandom();
+        private static readonly IRandomGenerator Generator = new DigestRandomGenerator(new Sha256Digest());
+        private static readonly SecureRandom Random = new SecureRandom(Generator);
 
         public byte[] GenerateChallenge()
         {


### PR DESCRIPTION
Upgraded the random challenge generator since version 1.7 of bouncy castle uses sha1 which the security industry seems to be moving away from.