### PR TITLE
Fix typo in class/interface: Memeber -> Member

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 *.user
 *.sln.docstates
 *.userprefs
+.vs/
+.vscode/
 
 # Build results
 [Dd]ebug/

--- a/BaseLibrary/BaseLibrary.csproj
+++ b/BaseLibrary/BaseLibrary.csproj
@@ -52,7 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="IDataContext.cs" />
-    <Compile Include="IMemeberShipService.cs" />
+    <Compile Include="IMemberShipService.cs" />
     <Compile Include="IUserRepository.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/BaseLibrary/IMemberShipService.cs
+++ b/BaseLibrary/IMemberShipService.cs
@@ -3,7 +3,7 @@ using DataModels;
 
 namespace BaseLibrary
 {
-    public interface IMemeberShipService
+    public interface IMemberShipService
     {
         bool SaveNewUser(string userName, string password);
 

--- a/DemoU2FSite/Bootstrapper.cs
+++ b/DemoU2FSite/Bootstrapper.cs
@@ -27,7 +27,7 @@ namespace DemoU2FSite
 
             // e.g. container.RegisterType<ITestService, TestService>();    
             container.RegisterType<IDataContext, Repositories.Context.DataContext>();
-            container.RegisterType<IMemeberShipService, MemeberShipService>();
+            container.RegisterType<IMemberShipService, MemberShipService>();
             container.RegisterType<IUserRepository, UserRepository>();
             RegisterTypes(container);
 

--- a/DemoU2FSite/Controllers/HomeController.cs
+++ b/DemoU2FSite/Controllers/HomeController.cs
@@ -12,11 +12,11 @@ namespace DemoU2FSite.Controllers
 {
     public class HomeController : Controller
     {
-        private readonly IMemeberShipService _memeberShipService;
+        private readonly IMemberShipService _memberShipService;
 
-        public HomeController(IMemeberShipService memeberShipService)
+        public HomeController(IMemberShipService memberShipService)
         {
-            _memeberShipService = memeberShipService;
+            _memberShipService = memberShipService;
         }
         
         [System.Web.Mvc.AllowAnonymous]
@@ -37,14 +37,14 @@ namespace DemoU2FSite.Controllers
         public ActionResult BeginLogin(BeginLoginModel model)
         {
             if ((string.IsNullOrWhiteSpace(model.Password))
-                || !_memeberShipService.IsUserRegistered(model.UserName.Trim()))
+                || !_memberShipService.IsUserRegistered(model.UserName.Trim()))
             {
                 // If we got this far, something failed, redisplay form
                 ModelState.AddModelError("CustomError", "User has not been registered.");
                 return View("Login", model);
             }
 
-            if (!_memeberShipService.IsValidUserNameAndPassword(model.UserName.Trim(), model.Password.Trim()))
+            if (!_memberShipService.IsValidUserNameAndPassword(model.UserName.Trim(), model.Password.Trim()))
             {
                 ModelState.AddModelError("CustomError", "User/Password is not invalid.");
                 return View("Login", model);
@@ -52,7 +52,7 @@ namespace DemoU2FSite.Controllers
 
             try
             {
-                List<ServerChallenge> serverChallenge = _memeberShipService.GenerateServerChallenges(model.UserName.Trim());
+                List<ServerChallenge> serverChallenge = _memberShipService.GenerateServerChallenges(model.UserName.Trim());
 
                 if(serverChallenge == null || serverChallenge.Count == 0)
                     throw new Exception("No server challenges were generated.");
@@ -81,7 +81,7 @@ namespace DemoU2FSite.Controllers
         [ValidateAntiForgeryToken]
         public ActionResult CompletedLogin(CompleteLoginModel model)
         {
-            if (!_memeberShipService.IsUserRegistered(model.UserName.Trim()))
+            if (!_memberShipService.IsUserRegistered(model.UserName.Trim()))
             {
                 // If we got this far, something failed, redisplay form
                 ModelState.AddModelError("", "User has not been registered.");
@@ -90,7 +90,7 @@ namespace DemoU2FSite.Controllers
 
             try
             {
-                if (!_memeberShipService.AuthenticateUser(model.UserName.Trim(), model.DeviceResponse.Trim()))
+                if (!_memberShipService.AuthenticateUser(model.UserName.Trim(), model.DeviceResponse.Trim()))
                     throw new Exception("Device response did not work with user.");
 
                 FormsAuthentication.SetAuthCookie(model.UserName, true);
@@ -116,7 +116,7 @@ namespace DemoU2FSite.Controllers
         [ValidateAntiForgeryToken]
         public ActionResult BeginRegister([FromBody] RegisterModel value)
         {
-            if (_memeberShipService.IsUserRegistered(value.UserName))
+            if (_memberShipService.IsUserRegistered(value.UserName))
             {
                 ModelState.AddModelError("CustomError", "User is already registered.");
                 return View("Register", value);
@@ -128,8 +128,8 @@ namespace DemoU2FSite.Controllers
             {
                 try
                 {
-                    _memeberShipService.SaveNewUser(value.UserName, value.Password);
-                    ServerRegisterResponse serverRegisterResponse = _memeberShipService.GenerateServerChallenge(value.UserName.Trim());
+                    _memberShipService.SaveNewUser(value.UserName, value.Password);
+                    ServerRegisterResponse serverRegisterResponse = _memberShipService.GenerateServerChallenge(value.UserName.Trim());
                     CompleteRegisterModel registerModel = new CompleteRegisterModel
                     {
                         UserName = value.UserName,
@@ -163,7 +163,7 @@ namespace DemoU2FSite.Controllers
             {
                 try
                 {
-                    value.DeviceResponse = _memeberShipService.CompleteRegistration(value.UserName.Trim(),
+                    value.DeviceResponse = _memberShipService.CompleteRegistration(value.UserName.Trim(),
                         value.DeviceResponse.Trim())
                         ? "Registration was successful."
                         : "Registration failed.";

--- a/DemoU2FSite/Controllers/ProfileController.cs
+++ b/DemoU2FSite/Controllers/ProfileController.cs
@@ -11,12 +11,12 @@ namespace DemoU2FSite.Controllers
     public class ProfileController : Controller
     {
         private readonly IUserRepository _userRepository;
-        private readonly IMemeberShipService _memeberShipService;
+        private readonly IMemberShipService _memberShipService;
 
-        public ProfileController(IUserRepository userRepository, IMemeberShipService memeberShipService)
+        public ProfileController(IUserRepository userRepository, IMemberShipService memberShipService)
         {
             _userRepository = userRepository;
-            _memeberShipService = memeberShipService;
+            _memberShipService = memberShipService;
         }
 
         public ActionResult Index()
@@ -37,12 +37,12 @@ namespace DemoU2FSite.Controllers
                 ModelState.AddModelError("", "User has timed out.");
                 RedirectToAction("Login", "Home");
             }
-            _memeberShipService.CompleteRegistration(HttpContext.User.Identity.Name, deviceResponse);
+            _memberShipService.CompleteRegistration(HttpContext.User.Identity.Name, deviceResponse);
         }
 
         public JsonResult GetChallenge()
         {
-            ServerRegisterResponse serverRegisterResponse = _memeberShipService.GenerateServerChallenge(HttpContext.User.Identity.Name);
+            ServerRegisterResponse serverRegisterResponse = _memberShipService.GenerateServerChallenge(HttpContext.User.Identity.Name);
             CompleteRegisterModel registerModel = new CompleteRegisterModel
             {
                 UserName = HttpContext.User.Identity.Name,

--- a/Services/MemberShipService.cs
+++ b/Services/MemberShipService.cs
@@ -11,18 +11,18 @@ using u2flib.Util;
 
 namespace Services
 {
-    public class MemeberShipService : IMemeberShipService
+    public class MemberShipService : IMemberShipService
     {
         private readonly IUserRepository _userRepository;
         // NOTE: THIS HAS TO BE UPDATED TO MATCH YOUR SITE/EXAMPLE and sites must be https for chrome plugin
         private const string DemoAppId = "https://localhost:44301";
 
-        public MemeberShipService(IUserRepository userRepository)
+        public MemberShipService(IUserRepository userRepository)
         {
             _userRepository = userRepository;
         }
 
-        #region IMemeberShipService methods
+        #region IMemberShipService methods
 
         public bool SaveNewUser(string userName, string password)
         {

--- a/Services/Services.csproj
+++ b/Services/Services.csproj
@@ -42,7 +42,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="MemeberShipService.cs" />
+    <Compile Include="MemberShipService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/UnitTests/HomeControllerUnitTests.cs
+++ b/UnitTests/HomeControllerUnitTests.cs
@@ -12,18 +12,18 @@ namespace UnitTests
     [TestClass]
     public class HomeControllerUnitTests
     {
-        private Mock<IMemeberShipService> _memeberShipService;
+        private Mock<IMemberShipService> _memberShipService;
 
         [TestInitialize]
         public void Setup()
         {
-            _memeberShipService = new Mock<IMemeberShipService>();
+            _memberShipService = new Mock<IMemberShipService>();
         }
 
         [TestMethod]
         public void HomeController_BeginLoginNoUsername()
         {
-            HomeController homeController = new HomeController(_memeberShipService.Object);
+            HomeController homeController = new HomeController(_memberShipService.Object);
             BeginLoginModel beginLoginModel = new BeginLoginModel();
 
             ViewResult result = homeController.BeginLogin(beginLoginModel) as ViewResult;
@@ -37,12 +37,12 @@ namespace UnitTests
         [TestMethod]
         public void HomeController_BeginLoginException()
         {
-            _memeberShipService.Setup(s => s.IsUserRegistered(It.Is<string>(p => p == "tester"))).Returns(true);
-            _memeberShipService.Setup(s => s.IsValidUserNameAndPassword(It.Is<string>(p => p == "tester"), It.Is<string>(p => p == "password"))).Returns(true).Verifiable();
-            _memeberShipService.Setup(s => s.GenerateServerChallenges(It.Is<string>(p => p == "tester")))
+            _memberShipService.Setup(s => s.IsUserRegistered(It.Is<string>(p => p == "tester"))).Returns(true);
+            _memberShipService.Setup(s => s.IsValidUserNameAndPassword(It.Is<string>(p => p == "tester"), It.Is<string>(p => p == "password"))).Returns(true).Verifiable();
+            _memberShipService.Setup(s => s.GenerateServerChallenges(It.Is<string>(p => p == "tester")))
                 .Returns(new List<ServerChallenge>());
 
-            HomeController homeController = new HomeController(_memeberShipService.Object);
+            HomeController homeController = new HomeController(_memberShipService.Object);
             BeginLoginModel beginLoginModel = new BeginLoginModel
             {
                 UserName = "tester",
@@ -59,7 +59,7 @@ namespace UnitTests
         [TestMethod]
         public void HomeController_BeginLoginNoPassword()
         {
-            HomeController homeController = new HomeController(_memeberShipService.Object);
+            HomeController homeController = new HomeController(_memberShipService.Object);
             BeginLoginModel beginLoginModel = new BeginLoginModel
                                               {
                                                   UserName = "tester"
@@ -76,8 +76,8 @@ namespace UnitTests
         [TestMethod]
         public void HomeController_BeginLoginWithUsernameAndPassword()
         {
-            _memeberShipService.Setup(s => s.IsUserRegistered(It.Is<string>(p => p == "tester"))).Returns(true);
-            _memeberShipService.Setup(s => s.GenerateServerChallenges(It.Is<string>(p => p == "tester")))
+            _memberShipService.Setup(s => s.IsUserRegistered(It.Is<string>(p => p == "tester"))).Returns(true);
+            _memberShipService.Setup(s => s.GenerateServerChallenges(It.Is<string>(p => p == "tester")))
                 .Returns(new List<ServerChallenge>
             {
                 new ServerChallenge
@@ -88,9 +88,9 @@ namespace UnitTests
                     keyHandle = "notreallykeyhandle",
                 }
             }).Verifiable();
-            _memeberShipService.Setup(s => s.IsValidUserNameAndPassword(It.Is<string>(p => p == "tester"), It.Is<string>(p => p == "password"))).Returns(true).Verifiable();
+            _memberShipService.Setup(s => s.IsValidUserNameAndPassword(It.Is<string>(p => p == "tester"), It.Is<string>(p => p == "password"))).Returns(true).Verifiable();
 
-            HomeController homeController = new HomeController(_memeberShipService.Object);
+            HomeController homeController = new HomeController(_memberShipService.Object);
             BeginLoginModel beginLoginModel = new BeginLoginModel
             {
                 UserName = "tester",
@@ -102,13 +102,13 @@ namespace UnitTests
             Assert.IsNotNull(result);
             Assert.IsTrue(homeController.ModelState.IsValid);
             Assert.AreEqual("FinishLogin", result.ViewName);
-            _memeberShipService.VerifyAll();
+            _memberShipService.VerifyAll();
         }
 
         [TestMethod]
         public void HomeController_Register()
         {
-            HomeController homeController = new HomeController(_memeberShipService.Object);
+            HomeController homeController = new HomeController(_memberShipService.Object);
 
             ViewResult result = homeController.Register() as ViewResult;
 
@@ -119,10 +119,10 @@ namespace UnitTests
         [TestMethod]
         public void HomeController_BeginLoginExceptionThrown()
         {
-            _memeberShipService.Setup(s => s.GenerateServerChallenges(It.IsAny<string>())).Throws(new Exception());
-            _memeberShipService.Setup(s => s.IsUserRegistered(It.IsAny<string>())).Returns(true);
+            _memberShipService.Setup(s => s.GenerateServerChallenges(It.IsAny<string>())).Throws(new Exception());
+            _memberShipService.Setup(s => s.IsUserRegistered(It.IsAny<string>())).Returns(true);
 
-            HomeController homeController = new HomeController(_memeberShipService.Object);
+            HomeController homeController = new HomeController(_memberShipService.Object);
             BeginLoginModel beginLoginModel = new BeginLoginModel { UserName = "UserName", Password = "Password"};
 
             ViewResult result = homeController.BeginLogin(beginLoginModel) as ViewResult;
@@ -135,10 +135,10 @@ namespace UnitTests
         [TestMethod]
         public void HomeController_CompletedLoginExceptionThrown()
         {
-            _memeberShipService.Setup(s => s.AuthenticateUser(It.IsAny<string>(), It.IsAny<string>())).Throws(new Exception());
-            _memeberShipService.Setup(s => s.IsUserRegistered(It.IsAny<string>())).Returns(true);
+            _memberShipService.Setup(s => s.AuthenticateUser(It.IsAny<string>(), It.IsAny<string>())).Throws(new Exception());
+            _memberShipService.Setup(s => s.IsUserRegistered(It.IsAny<string>())).Returns(true);
 
-            HomeController homeController = new HomeController(_memeberShipService.Object);
+            HomeController homeController = new HomeController(_memberShipService.Object);
             CompleteLoginModel beginLoginModel = new CompleteLoginModel { UserName = "UserName" };
 
             ViewResult result = homeController.CompletedLogin(beginLoginModel) as ViewResult;
@@ -151,9 +151,9 @@ namespace UnitTests
         [TestMethod]
         public void HomeController_CompletedLoginNoUsername()
         {
-            _memeberShipService.Setup(s => s.IsUserRegistered(It.IsAny<string>())).Returns(false);
+            _memberShipService.Setup(s => s.IsUserRegistered(It.IsAny<string>())).Returns(false);
 
-            HomeController homeController = new HomeController(_memeberShipService.Object);
+            HomeController homeController = new HomeController(_memberShipService.Object);
             CompleteLoginModel beginLoginModel = new CompleteLoginModel{UserName = string.Empty};
 
             ViewResult result = homeController.CompletedLogin(beginLoginModel) as ViewResult;
@@ -168,10 +168,10 @@ namespace UnitTests
         [TestMethod]
         public void HomeController_CompletedLoginWithUsername()
         {
-            _memeberShipService.Setup(s => s.IsUserRegistered(It.Is<string>(p => p == "tester"))).Returns(true);
-            _memeberShipService.Setup(s => s.AuthenticateUser(It.Is<string>(p => p == "tester"), It.Is<string>(p => p == "notrealdeviceresponse"))).Returns(true);
+            _memberShipService.Setup(s => s.IsUserRegistered(It.Is<string>(p => p == "tester"))).Returns(true);
+            _memberShipService.Setup(s => s.AuthenticateUser(It.Is<string>(p => p == "tester"), It.Is<string>(p => p == "notrealdeviceresponse"))).Returns(true);
 
-            HomeController homeController = new HomeController(_memeberShipService.Object);
+            HomeController homeController = new HomeController(_memberShipService.Object);
             CompleteLoginModel beginLoginModel = new CompleteLoginModel
                                                  {
                                                      UserName = "tester",
@@ -187,7 +187,7 @@ namespace UnitTests
         [TestMethod]
         public void HomeController_BeginRegisterNoPasswordOrUsername()
         {
-            HomeController homeController = new HomeController(_memeberShipService.Object);
+            HomeController homeController = new HomeController(_memberShipService.Object);
             RegisterModel registerModel = new RegisterModel();
 
             ViewResult result = homeController.BeginRegister(registerModel) as ViewResult;
@@ -200,7 +200,7 @@ namespace UnitTests
         [TestMethod]
         public void HomeController_BeginRegisterBadMatchPasswordsAndUsername()
         {
-            HomeController homeController = new HomeController(_memeberShipService.Object);
+            HomeController homeController = new HomeController(_memberShipService.Object);
             RegisterModel registerModel = new RegisterModel
                                           {
                                               UserName = "tester",
@@ -218,10 +218,10 @@ namespace UnitTests
         [TestMethod]
         public void HomeController_BeginRegisterPasswordsAndUsername()
         {
-            _memeberShipService.Setup(
+            _memberShipService.Setup(
                 e => e.GenerateServerChallenge(It.Is<string>(p => p == "tester")))
                 .Returns(new ServerRegisterResponse());
-            HomeController homeController = new HomeController(_memeberShipService.Object);
+            HomeController homeController = new HomeController(_memberShipService.Object);
             RegisterModel registerModel = new RegisterModel
             {
                 UserName = "tester",
@@ -239,8 +239,8 @@ namespace UnitTests
         [TestMethod]
         public void HomeController_BeginRegisterDuplicateUser()
         {
-            _memeberShipService.Setup(s => s.IsUserRegistered(It.Is<string>(p => p == "tester"))).Returns(true);
-            HomeController homeController = new HomeController(_memeberShipService.Object);
+            _memberShipService.Setup(s => s.IsUserRegistered(It.Is<string>(p => p == "tester"))).Returns(true);
+            HomeController homeController = new HomeController(_memberShipService.Object);
 
             RegisterModel registerModel = new RegisterModel
             {
@@ -259,7 +259,7 @@ namespace UnitTests
         [TestMethod]
         public void HomeController_CompleteRegisterNoDeviceTokenOrUsername()
         {
-            HomeController homeController = new HomeController(_memeberShipService.Object);
+            HomeController homeController = new HomeController(_memberShipService.Object);
             CompleteRegisterModel registerModel = new CompleteRegisterModel();
 
             ViewResult result = homeController.CompleteRegister(registerModel) as ViewResult;
@@ -272,8 +272,8 @@ namespace UnitTests
         [TestMethod]
         public void HomeController_CompleteRegisterExceptionThrown()
         {
-            _memeberShipService.Setup(s => s.CompleteRegistration(It.IsAny<string>(), It.IsAny<string>())).Throws(new Exception());
-            HomeController homeController = new HomeController(_memeberShipService.Object);
+            _memberShipService.Setup(s => s.CompleteRegistration(It.IsAny<string>(), It.IsAny<string>())).Throws(new Exception());
+            HomeController homeController = new HomeController(_memberShipService.Object);
             CompleteRegisterModel registerModel = new CompleteRegisterModel
                                                   {
                                                       UserName = "username",
@@ -290,7 +290,7 @@ namespace UnitTests
         [TestMethod]
         public void HomeController_CompleteRegisterWithDeviceTokenNoUsername()
         {
-            HomeController homeController = new HomeController(_memeberShipService.Object);
+            HomeController homeController = new HomeController(_memberShipService.Object);
             CompleteRegisterModel registerModel = new CompleteRegisterModel{DeviceResponse = "notrealdevicetoken"};
 
             ViewResult result = homeController.CompleteRegister(registerModel) as ViewResult;
@@ -303,7 +303,7 @@ namespace UnitTests
         [TestMethod]
         public void HomeController_CompleteRegisterWithUsernameNoDeviceToken()
         {
-            HomeController homeController = new HomeController(_memeberShipService.Object);
+            HomeController homeController = new HomeController(_memberShipService.Object);
             CompleteRegisterModel registerModel = new CompleteRegisterModel { UserName = "tester" };
 
             ViewResult result = homeController.CompleteRegister(registerModel) as ViewResult;
@@ -316,9 +316,9 @@ namespace UnitTests
         [TestMethod]
         public void HomeController_CompleteRegisterWithUsernameAndDeviceToken()
         {
-            _memeberShipService.Setup(
+            _memberShipService.Setup(
                 e => e.CompleteRegistration(It.Is<string>(p => p == "tester"), It.Is<string>(p => p == "notreallydevicetoken"))).Returns(true);
-            HomeController homeController = new HomeController(_memeberShipService.Object);
+            HomeController homeController = new HomeController(_memberShipService.Object);
             CompleteRegisterModel registerModel = new CompleteRegisterModel
                                                   {
                                                       UserName = "tester",
@@ -335,7 +335,7 @@ namespace UnitTests
         [TestMethod]
         public void HomeController_Index()
         {
-            HomeController homeController = new HomeController(_memeberShipService.Object);
+            HomeController homeController = new HomeController(_memberShipService.Object);
             ViewResult result = homeController.Index() as ViewResult;
 
             Assert.IsNotNull(result);
@@ -345,7 +345,7 @@ namespace UnitTests
         [TestMethod]
         public void HomeController_Login()
         {
-            HomeController homeController = new HomeController(_memeberShipService.Object);
+            HomeController homeController = new HomeController(_memberShipService.Object);
             ViewResult result = homeController.Login() as ViewResult;
 
             Assert.IsNotNull(result);

--- a/UnitTests/MemberShipServiceUnitTests.cs
+++ b/UnitTests/MemberShipServiceUnitTests.cs
@@ -14,7 +14,7 @@ using DeviceRegistration = u2flib.Data.DeviceRegistration;
 namespace UnitTests
 {
     [TestClass]
-    public class MemeberShipServiceUnitTests
+    public class MemberShipServiceUnitTests
     {
         private Mock<IUserRepository> _userRepository;
         private RegisterResponse _registerResponse;
@@ -56,61 +56,61 @@ namespace UnitTests
         }
 
         [TestMethod]
-        public void MemeberShipService_SaveBlankUserName()
+        public void MemberShipService_SaveBlankUserName()
         {
-            MemeberShipService memeberShipService = new MemeberShipService(_userRepository.Object);
+            MemberShipService memberShipService = new MemberShipService(_userRepository.Object);
 
-            var results = memeberShipService.SaveNewUser("", "");
+            var results = memberShipService.SaveNewUser("", "");
 
             Assert.IsFalse(results);
         }
 
         [TestMethod]
-        public void MemeberShipService_SaveBlankPassword()
+        public void MemberShipService_SaveBlankPassword()
         {
-            MemeberShipService memeberShipService = new MemeberShipService(_userRepository.Object);
+            MemberShipService memberShipService = new MemberShipService(_userRepository.Object);
 
-            var results = memeberShipService.SaveNewUser("someone", "");
+            var results = memberShipService.SaveNewUser("someone", "");
 
             Assert.IsFalse(results);
         }
 
         [TestMethod]
-        public void MemeberShipService_CannotSaveDuplicateUserName()
+        public void MemberShipService_CannotSaveDuplicateUserName()
         {
             _userRepository.Setup(s => s.FindUser(It.Is<string>(p => p == "someone"))).Returns(new User()).Verifiable();
-            MemeberShipService memeberShipService = new MemeberShipService(_userRepository.Object);
+            MemberShipService memberShipService = new MemberShipService(_userRepository.Object);
 
-            var results = memeberShipService.SaveNewUser("someone", "password1");
+            var results = memberShipService.SaveNewUser("someone", "password1");
 
             Assert.IsFalse(results);
             _userRepository.VerifyAll();
         }
 
         [TestMethod]
-        public void MemeberShipService_SaveUserName()
+        public void MemberShipService_SaveUserName()
         {
             _userRepository.Setup(s => s.FindUser(It.Is<string>(p => p == "someone"))).Returns((User) null).Verifiable();
             _userRepository.Setup(s => s.AddUser(It.Is<string>(p => p == "someone"), It.IsAny<string>())).Verifiable();
-            MemeberShipService memeberShipService = new MemeberShipService(_userRepository.Object);
+            MemberShipService memberShipService = new MemberShipService(_userRepository.Object);
 
-            var results = memeberShipService.SaveNewUser("someone", "password1");
+            var results = memberShipService.SaveNewUser("someone", "password1");
 
             Assert.IsTrue(results);
             _userRepository.VerifyAll();
         }
 
         [TestMethod]
-        public void MemeberShipService_GenerateServerChallengeSucess()
+        public void MemberShipService_GenerateServerChallengeSucess()
         {
             _userRepository.Setup(e => e.FindUser("test")).Returns(_user);
             _userRepository.Setup(
                 e =>
                 e.SaveUserAuthenticationRequest(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
                                                 It.IsAny<string>()));
-            MemeberShipService memeberShipService = new MemeberShipService(_userRepository.Object);
+            MemberShipService memberShipService = new MemberShipService(_userRepository.Object);
 
-            var result = memeberShipService.GenerateServerChallenges("test");
+            var result = memberShipService.GenerateServerChallenges("test");
 
             Assert.IsNotNull(result);
             _userRepository.Verify(
@@ -120,63 +120,63 @@ namespace UnitTests
         }
 
         [TestMethod]
-        public void MemeberShipService_GenerateServerChallengeNoDeviceFound()
+        public void MemberShipService_GenerateServerChallengeNoDeviceFound()
         {
             _userRepository.Setup(e => e.FindUser("test")).Returns(new User { DeviceRegistrations = new Collection<Device>() });
-            MemeberShipService memeberShipService = new MemeberShipService(_userRepository.Object);
+            MemberShipService memberShipService = new MemberShipService(_userRepository.Object);
 
-            var result = memeberShipService.GenerateServerChallenges("test");
+            var result = memberShipService.GenerateServerChallenges("test");
 
             Assert.IsNull(result);
             _userRepository.Verify(e => e.FindUser("test"), Times.Once);
         }
 
         [TestMethod]
-        public void MemeberShipService_GenerateServerChallengeNoUserFound()
+        public void MemberShipService_GenerateServerChallengeNoUserFound()
         {
             _userRepository.Setup(e => e.FindUser("test"));
-            MemeberShipService memeberShipService = new MemeberShipService(_userRepository.Object);
+            MemberShipService memberShipService = new MemberShipService(_userRepository.Object);
 
-            var result = memeberShipService.GenerateServerChallenges("test");
+            var result = memberShipService.GenerateServerChallenges("test");
 
             Assert.IsNull(result);
             _userRepository.Verify(e => e.FindUser("test"), Times.Once);
         }
 
         [TestMethod]
-        public void MemeberShipService_GenerateServerChallengeNoUsername()
+        public void MemberShipService_GenerateServerChallengeNoUsername()
         {
-            MemeberShipService memeberShipService = new MemeberShipService(_userRepository.Object);
+            MemberShipService memberShipService = new MemberShipService(_userRepository.Object);
 
-            var result = memeberShipService.GenerateServerChallenges("");
+            var result = memberShipService.GenerateServerChallenges("");
 
             Assert.IsNull(result);
         }
         
         [TestMethod]
-        public void MemeberShipService_GenerateServerRegistration()
+        public void MemberShipService_GenerateServerRegistration()
         {
             _userRepository.Setup(e => e.SaveUserAuthenticationRequest(It.Is<string>(p => p == "test"), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()));
-            MemeberShipService memeberShipService = new MemeberShipService(_userRepository.Object);
+            MemberShipService memberShipService = new MemberShipService(_userRepository.Object);
 
-            var result = memeberShipService.GenerateServerChallenge("test");
+            var result = memberShipService.GenerateServerChallenge("test");
 
             Assert.IsNotNull(result);
             _userRepository.Verify(e => e.SaveUserAuthenticationRequest(It.Is<string>(p => p == "test"), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
         }
 
         [TestMethod]
-        public void MemeberShipService_GenerateServerRegistrationForUser()
+        public void MemberShipService_GenerateServerRegistrationForUser()
         {
-            MemeberShipService memeberShipService = new MemeberShipService(_userRepository.Object);
+            MemberShipService memberShipService = new MemberShipService(_userRepository.Object);
 
-            var result = memeberShipService.GenerateServerChallenge("test");
+            var result = memberShipService.GenerateServerChallenge("test");
 
             Assert.IsNotNull(result);
         }
         
         [TestMethod]
-        public void MemeberShipService_CompleteRegistrationSucess()
+        public void MemberShipService_CompleteRegistrationSucess()
         {
             Device device = _user.DeviceRegistrations.First();
             _user.AuthenticationRequest.First().Challenge = _startedRegistration.Challenge;
@@ -185,9 +185,9 @@ namespace UnitTests
             _userRepository.Setup(e => e.FindUser("test")).Returns(_user);
             _userRepository.Setup(e => e.RemoveUsersAuthenticationRequests("test"));
             _userRepository.Setup(e => e.AddDeviceRegistration("Test", device.AttestationCert, Convert.ToUInt32(device.Counter), device.KeyHandle, device.PublicKey));
-            MemeberShipService memeberShipService = new MemeberShipService(_userRepository.Object);
+            MemberShipService memberShipService = new MemberShipService(_userRepository.Object);
 
-            var result = memeberShipService.CompleteRegistration("test", _registerResponse.ToJson());
+            var result = memberShipService.CompleteRegistration("test", _registerResponse.ToJson());
 
             Assert.IsTrue(result);
             _userRepository.Verify(e => e.RemoveUsersAuthenticationRequests("test"), Times.Once);
@@ -195,51 +195,51 @@ namespace UnitTests
         }
 
         [TestMethod]
-        public void MemeberShipService_CompleteRegistrationNoUserFound()
+        public void MemberShipService_CompleteRegistrationNoUserFound()
         {
             _userRepository.Setup(e => e.FindUser("test"));
-            MemeberShipService memeberShipService = new MemeberShipService(_userRepository.Object);
+            MemberShipService memberShipService = new MemberShipService(_userRepository.Object);
 
-            var result = memeberShipService.CompleteRegistration("test", _authenticateResponse.ToJson());
+            var result = memberShipService.CompleteRegistration("test", _authenticateResponse.ToJson());
 
             Assert.IsFalse(result);
             _userRepository.Verify(e => e.FindUser("test"), Times.Once);
         }
 
         [TestMethod]
-        public void MemeberShipService_CompleteRegistrationUserFoundWithNoAuthenticationRequest()
+        public void MemberShipService_CompleteRegistrationUserFoundWithNoAuthenticationRequest()
         {
             _userRepository.Setup(e => e.FindUser("test")).Returns(new User());
-            MemeberShipService memeberShipService = new MemeberShipService(_userRepository.Object);
+            MemberShipService memberShipService = new MemberShipService(_userRepository.Object);
 
-            var result = memeberShipService.CompleteRegistration("test", _authenticateResponse.ToJson());
+            var result = memberShipService.CompleteRegistration("test", _authenticateResponse.ToJson());
 
             Assert.IsFalse(result);
             _userRepository.Verify(e => e.FindUser("test"), Times.Once);
         }
 
         [TestMethod]
-        public void MemeberShipService_CompleteRegistrationNoDeviceResponse()
+        public void MemberShipService_CompleteRegistrationNoDeviceResponse()
         {
-            MemeberShipService memeberShipService = new MemeberShipService(_userRepository.Object);
+            MemberShipService memberShipService = new MemberShipService(_userRepository.Object);
 
-            var result = memeberShipService.CompleteRegistration("test", "");
+            var result = memberShipService.CompleteRegistration("test", "");
 
             Assert.IsFalse(result);
         }
 
         [TestMethod]
-        public void MemeberShipService_CompleteRegistrationNoUserName()
+        public void MemberShipService_CompleteRegistrationNoUserName()
         {
-            MemeberShipService memeberShipService = new MemeberShipService(_userRepository.Object);
+            MemberShipService memberShipService = new MemberShipService(_userRepository.Object);
 
-            var result = memeberShipService.CompleteRegistration("", "nothing");
+            var result = memberShipService.CompleteRegistration("", "nothing");
 
             Assert.IsFalse(result);
         }
 
         [TestMethod]
-        public void MemeberShipService_IsUserRegistered()
+        public void MemberShipService_IsUserRegistered()
         {
             _userRepository.Setup(e => e.FindUser(It.Is<string>(p => p == "test"))).Returns(new User
                 {
@@ -248,16 +248,16 @@ namespace UnitTests
                             new Device()
                         }
                 });
-            MemeberShipService memeberShipService = new MemeberShipService(_userRepository.Object);
+            MemberShipService memberShipService = new MemberShipService(_userRepository.Object);
 
-            var result = memeberShipService.IsUserRegistered("test");
+            var result = memberShipService.IsUserRegistered("test");
 
             Assert.IsTrue(result);
             _userRepository.Verify(e => e.FindUser("test"), Times.Once);
         }
 
         [TestMethod]
-        public void MemeberShipService_IsUserRegisteredNoUserName()
+        public void MemberShipService_IsUserRegisteredNoUserName()
         {
             _userRepository.Setup(e => e.FindUser(It.Is<string>(p => p == "test"))).Returns(new User
             {
@@ -266,74 +266,74 @@ namespace UnitTests
                             new Device()
                         }
             });
-            MemeberShipService memeberShipService = new MemeberShipService(_userRepository.Object);
+            MemberShipService memberShipService = new MemberShipService(_userRepository.Object);
 
-            var result = memeberShipService.IsUserRegistered("");
+            var result = memberShipService.IsUserRegistered("");
 
             Assert.IsFalse(result);
             _userRepository.Verify(e => e.FindUser("test"), Times.Never);
         }
 
         [TestMethod]
-        public void MemeberShipService_IsUserRegisteredNoUserFound()
+        public void MemberShipService_IsUserRegisteredNoUserFound()
         {
             _userRepository.Setup(e => e.FindUser(It.Is<string>(p => p == "test")));
-            MemeberShipService memeberShipService = new MemeberShipService(_userRepository.Object);
+            MemberShipService memberShipService = new MemberShipService(_userRepository.Object);
 
-            var result = memeberShipService.IsUserRegistered("test");
+            var result = memberShipService.IsUserRegistered("test");
 
             Assert.IsFalse(result);
             _userRepository.Verify(e => e.FindUser("test"), Times.Once);
         }
 
         [TestMethod]
-        public void MemeberShipService_AuthenticateUserNoUserName()
+        public void MemberShipService_AuthenticateUserNoUserName()
         {
-            MemeberShipService memeberShipService = new MemeberShipService(_userRepository.Object);
+            MemberShipService memberShipService = new MemberShipService(_userRepository.Object);
 
-            var result = memeberShipService.AuthenticateUser("", _authenticateResponse.ToJson());
+            var result = memberShipService.AuthenticateUser("", _authenticateResponse.ToJson());
 
             Assert.IsFalse(result);
         }
 
         [TestMethod]
-        public void MemeberShipService_AuthenticateUserNoDeviceResponse()
+        public void MemberShipService_AuthenticateUserNoDeviceResponse()
         {
-            MemeberShipService memeberShipService = new MemeberShipService(_userRepository.Object);
+            MemberShipService memberShipService = new MemberShipService(_userRepository.Object);
 
-            var result = memeberShipService.AuthenticateUser("test", null);
+            var result = memberShipService.AuthenticateUser("test", null);
 
             Assert.IsFalse(result);
         }
 
         [TestMethod]
-        public void MemeberShipService_AuthenticateUserNoUserFound()
+        public void MemberShipService_AuthenticateUserNoUserFound()
         {
             _userRepository.Setup(s => s.FindUser(It.Is<string>(p => p == "test")));
 
-            MemeberShipService memeberShipService = new MemeberShipService(_userRepository.Object);
+            MemberShipService memberShipService = new MemberShipService(_userRepository.Object);
 
-            var result = memeberShipService.AuthenticateUser("test", _authenticateResponse.ToJson());
+            var result = memberShipService.AuthenticateUser("test", _authenticateResponse.ToJson());
 
             Assert.IsFalse(result);
             _userRepository.Verify(e => e.FindUser("test"), Times.Once);
         }
 
         [TestMethod]
-        public void MemeberShipService_AuthenticateUserNoDeviceFound()
+        public void MemberShipService_AuthenticateUserNoDeviceFound()
         {
             _userRepository.Setup(s => s.FindUser(It.Is<string>(p => p == "test"))).Returns(new User { DeviceRegistrations = new Collection<Device>() });
 
-            MemeberShipService memeberShipService = new MemeberShipService(_userRepository.Object);
+            MemberShipService memberShipService = new MemberShipService(_userRepository.Object);
 
-            var result = memeberShipService.AuthenticateUser("test", _authenticateResponse.ToJson());
+            var result = memberShipService.AuthenticateUser("test", _authenticateResponse.ToJson());
 
             Assert.IsFalse(result);
             _userRepository.Verify(e => e.FindUser("test"), Times.Once);
         }
 
         [TestMethod]
-        public void MemeberShipService_AuthenticateUserNoAuthenticationRequestFound()
+        public void MemberShipService_AuthenticateUserNoAuthenticationRequestFound()
         {
             _userRepository.Setup(s => s.FindUser(It.Is<string>(p => p == "test"))).Returns(new User
             {
@@ -349,16 +349,16 @@ namespace UnitTests
                             }
             });
 
-            MemeberShipService memeberShipService = new MemeberShipService(_userRepository.Object);
+            MemberShipService memberShipService = new MemberShipService(_userRepository.Object);
 
-            var result = memeberShipService.AuthenticateUser("test", _authenticateResponse.ToJson());
+            var result = memberShipService.AuthenticateUser("test", _authenticateResponse.ToJson());
 
             Assert.IsFalse(result);
             _userRepository.Verify(e => e.FindUser("test"), Times.Once);
         }
 
         [TestMethod]
-        public void MemeberShipService_AuthenticateUser()
+        public void MemberShipService_AuthenticateUser()
         {
             _userRepository.Setup(e => e.FindUser(It.Is<string>(p => p == "test"))).Returns(
                 new User
@@ -387,9 +387,9 @@ namespace UnitTests
                     });
             _userRepository.Setup(e => e.RemoveUsersAuthenticationRequests(It.Is<string>(p => p == "test")));
             _userRepository.Setup(e => e.UpdateDeviceCounter(It.Is<string>(p => p == "test"), It.IsAny<byte[]>(), It.IsAny<uint>()));
-            MemeberShipService memeberShipService = new MemeberShipService(_userRepository.Object);
+            MemberShipService memberShipService = new MemberShipService(_userRepository.Object);
 
-            var result = memeberShipService.AuthenticateUser("test", _authenticateResponse.ToJson());
+            var result = memberShipService.AuthenticateUser("test", _authenticateResponse.ToJson());
 
             Assert.IsTrue(result);
             _userRepository.Verify(e => e.FindUser("test"), Times.Once);
@@ -397,46 +397,46 @@ namespace UnitTests
         }
 
         [TestMethod]
-        public void MemeberShipService_IsValidUserNameAndPasswordNullPassword()
+        public void MemberShipService_IsValidUserNameAndPasswordNullPassword()
         {
-            MemeberShipService memeberShipService = new MemeberShipService(_userRepository.Object);
+            MemberShipService memberShipService = new MemberShipService(_userRepository.Object);
 
-            var result = memeberShipService.IsValidUserNameAndPassword("test", null);
+            var result = memberShipService.IsValidUserNameAndPassword("test", null);
 
             Assert.IsFalse(result);
         }
 
         [TestMethod]
-        public void MemeberShipService_IsValidUserNameAndPassword()
+        public void MemberShipService_IsValidUserNameAndPassword()
         {
             _userRepository.Setup(e => e.FindUser(It.Is<string>(p => p == "test"))).Returns(new User { Password = "KSpjLUfp4gaP1Zu4F+6qhcBNhQeJJLRnN1zt9MBHWh8=" });
-            MemeberShipService memeberShipService = new MemeberShipService(_userRepository.Object);
+            MemberShipService memberShipService = new MemberShipService(_userRepository.Object);
 
-            var result = memeberShipService.IsValidUserNameAndPassword("test", "hashedPassword");
+            var result = memberShipService.IsValidUserNameAndPassword("test", "hashedPassword");
 
             Assert.IsTrue(result);
             _userRepository.Verify(e => e.FindUser(It.Is<string>(p => p == "test")), Times.Once);
         }
 
         [TestMethod]
-        public void MemeberShipService_IsValidUserNameAndPasswordNoUser()
+        public void MemberShipService_IsValidUserNameAndPasswordNoUser()
         {
             _userRepository.Setup(e => e.FindUser(It.Is<string>(p => p == "test")));
-            MemeberShipService memeberShipService = new MemeberShipService(_userRepository.Object);
+            MemberShipService memberShipService = new MemberShipService(_userRepository.Object);
 
-            var result = memeberShipService.IsValidUserNameAndPassword("test", "hashedPassword");
+            var result = memberShipService.IsValidUserNameAndPassword("test", "hashedPassword");
 
             Assert.IsFalse(result);
             _userRepository.Verify(e => e.FindUser(It.Is<string>(p => p == "test")), Times.Once);
         }
 
         [TestMethod]
-        public void MemeberShipService_IsValidUserNameAndPasswordBadPassword()
+        public void MemberShipService_IsValidUserNameAndPasswordBadPassword()
         {
             _userRepository.Setup(e => e.FindUser(It.Is<string>(p => p == "test"))).Returns(new User{Password = "notSame"});
-            MemeberShipService memeberShipService = new MemeberShipService(_userRepository.Object);
+            MemberShipService memberShipService = new MemberShipService(_userRepository.Object);
 
-            var result = memeberShipService.IsValidUserNameAndPassword("test", "hashedPassword");
+            var result = memberShipService.IsValidUserNameAndPassword("test", "hashedPassword");
 
             Assert.IsFalse(result);
             _userRepository.Verify(e => e.FindUser(It.Is<string>(p => p == "test")), Times.Once);

--- a/UnitTests/ProfileControllerUnitTests.cs
+++ b/UnitTests/ProfileControllerUnitTests.cs
@@ -16,7 +16,7 @@ namespace UnitTests
     public class ProfileControllerUnitTests
     {
         private Mock<IUserRepository> _userRepository;
-        private Mock<IMemeberShipService> _memberShipService;
+        private Mock<IMemberShipService> _memberShipService;
         private DeviceRegistration _deviceRegistration;
         private AuthenticateResponse _authenticateResponse;
         private User _user;
@@ -26,7 +26,7 @@ namespace UnitTests
         {
             CreateResponses();
             _userRepository = new Mock<IUserRepository>();
-            _memberShipService = new Mock<IMemeberShipService>();
+            _memberShipService = new Mock<IMemberShipService>();
             _user = new User
             {
                 Name = "test",

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -113,7 +113,7 @@
     <Compile Include="U2F\RandomChallengeGeneratorUnitTests.cs" />
     <Compile Include="U2F\U2FUnitTests.cs" />
     <Compile Include="U2F\UtilsUnitTests.cs" />
-    <Compile Include="MemeberShipServiceUnitTests.cs" />
+    <Compile Include="MemberShipServiceUnitTests.cs" />
     <Compile Include="ProfileControllerUnitTests.cs" />
     <Compile Include="UserRepositoryUnitTests.cs" />
   </ItemGroup>


### PR DESCRIPTION
This does change the public interface so I can understand if you don't merge it, but I thought I would fix it just in case you wanted to clean this up.