### PR TITLE
Use localdb instead of SqlExpress in sample application

### DIFF
--- a/DemoU2FSite/Web.config
+++ b/DemoU2FSite/Web.config
@@ -10,7 +10,7 @@
   </configSections>
   <connectionStrings>
     <!--Connect to local db via login computer (easier to setup)-->
-    <add name="DefaultConnection" connectionString="Data Source=.\sqlexpress;Initial Catalog=U2F_Demo; Trusted_Connection=yes;" providerName="System.Data.SqlClient" />
+    <add name="DefaultConnection" connectionString="Data Source=(LocalDb)\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\U2F_Demo.mdf;Initial Catalog=U2F_Demo;Integrated Security=True" providerName="System.Data.SqlClient" />
     <!--Connect to local db via username and password-->
     <!--<add name="DefaultConnection" connectionString="Data Source=.\sqlexpress;Initial Catalog=U2F;User ID=SA;Password=Password1" providerName="System.Data.SqlClient" />-->
   </connectionStrings>
@@ -128,7 +128,11 @@
     </assemblyBinding>
   </runtime>
   <entityFramework>
-    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
+    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
+      <parameters>
+        <parameter value="mssqllocaldb" />
+      </parameters>
+    </defaultConnectionFactory>
     <providers>
       <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
     </providers>


### PR DESCRIPTION
Since localdb is what's used in the latest visual studio samples and is more likely to be available on developer machines. 